### PR TITLE
Simple getter for BluePrint so that _data does not have to be used

### DIFF
--- a/broadbean/broadbean.py
+++ b/broadbean/broadbean.py
@@ -918,6 +918,12 @@ class Element:
 
         self._data[channel] = {}
         self._data[channel]['blueprint'] = newprint
+        
+    def getBluePrint(self, channel) -> BluePrint:
+        """
+        Gets a blueprint of the element from the specified channel.
+        """
+        return self._data[channel]['blueprint']
 
     def addArray(self, channel, array, SR, m1=None, m2=None):
         """


### PR DESCRIPTION
only
```
return self._data[channel]['blueprint']
``` 