### PR TITLE
feat/adding function to fuse sequential elements into one

### DIFF
--- a/broadbean/broadbean.py
+++ b/broadbean/broadbean.py
@@ -2258,12 +2258,12 @@ def joinElements(elem1: Element,
     If the channels specified in the two elements differ
     one can choose to do zero padding
     |-~-| |~--| |-~-~--|
-     +|~--|=|---~--|
+         +|~--|=|---~--|
     |---|       |------|
     If the channels are disjunct an overlap can be introduced
     |-~-|       |-~--|
-      |~--| |-~--|
-     +|~--|=|-~--|
+          |~--| |-~--|
+         +|~--|=|-~--|
     |---|       |----|
     It should also be possible at some point to join elements
     with overlap that share a common channel


### PR DESCRIPTION
Implemented as function and not as  operator, so that additional arguments are possible. Possibly add operator later for default args. Possible abiguity: does plus sequentially add elements or by channel?

function like in doc string:
```
    joins two elements by appending elem2 to elem1
    and returns a new atomic element:
    |-~-| |~--| |-~-~--|
    |---|+|~--|=|---~--|
    |---| |~--| |---~--|
    If the channels specified in the two elements differ
    one can choose to do zero padding
    |-~-| |~--| |-~-~--|
         +|~--|=|---~--|
    |---|       |------|
    If the channels are disjunct an overlap can be introduced
    |-~-|       |-~--|
          |~--| |-~--|
         +|~--|=|-~--|
    |---|       |----|
```